### PR TITLE
Add ReadOnlyPropertyInspector and FlagInspector for unity editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-n-ui",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "UI helper scripts",
   "main": "index.js",
   "repository": {

--- a/src/n-ui/Editor.meta
+++ b/src/n-ui/Editor.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 217cdc6ef0b154d0aa1f54ac9ef47020
+guid: e222615684bc5404ca59f5034cde088d
 folderAsset: yes
-timeCreated: 1480137314
-licenseType: Free
+timeCreated: 1504423936
+licenseType: Pro
 DefaultImporter:
   userData: 
   assetBundleName: 

--- a/src/n-ui/Editor/PropertyBindingInspector.cs
+++ b/src/n-ui/Editor/PropertyBindingInspector.cs
@@ -1,5 +1,8 @@
-using N.Package.Core;
+using UnityEngine;
 using UnityEditor;
+using System.Collections.Generic;
+using System;
+using N;
 using N.UI.Tools;
 
 namespace N.Package.UI {
@@ -45,7 +48,7 @@ namespace N.Package.UI {
       // If the component changed, repopulate the property list.
       EditorGUILayout.BeginHorizontal();
       if (new_target_component) {
-        N.Package.Core.Console.Log(selectTargetComponent.component);
+        N.Console.Log(selectTargetComponent.component);
         selectTargetProperty.bind(selectTargetComponent.component);
       }
       var new_target_property = selectTargetProperty.update();

--- a/src/n-ui/Editor/PropertyBindingInspector.cs
+++ b/src/n-ui/Editor/PropertyBindingInspector.cs
@@ -48,7 +48,7 @@ namespace N.Package.UI {
       // If the component changed, repopulate the property list.
       EditorGUILayout.BeginHorizontal();
       if (new_target_component) {
-        N.Console.Log(selectTargetComponent.component);
+        N.Package.Core.Console.Log(selectTargetComponent.component);
         selectTargetProperty.bind(selectTargetComponent.component);
       }
       var new_target_property = selectTargetProperty.update();

--- a/src/n-ui/FlagPropertyInspector.cs
+++ b/src/n-ui/FlagPropertyInspector.cs
@@ -1,0 +1,34 @@
+﻿#if UNITY_EDITOR
+using UnityEngine;
+using UnityEditor;
+
+namespace N.Package.UI
+{
+    /// <summary>
+    /// Use Enums as muli-select options, rather than single-select options
+    /// </summary>
+    public class FlagInspector : PropertyAttribute
+    {
+        public FlagInspector() { }
+    }
+
+    /// <summary>
+    /// Render the flags properly.
+    /// </summary>
+    [CustomPropertyDrawer(typeof(FlagInspector))]
+    public class FlagInspectorDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect _position, SerializedProperty _property, GUIContent _label)
+        {
+            _property.intValue = EditorGUI.MaskField(_position, _label, _property.intValue, _property.enumNames);
+        }
+    }
+}
+
+#else
+ 
+namespace N.Package.UI
+{
+    public class FlagInspector : System.Attribute { }
+}
+#endif

--- a/src/n-ui/FlagPropertyInspector.cs.meta
+++ b/src/n-ui/FlagPropertyInspector.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0605157c6275841eca3027bf036c37d7
+guid: 1243efdbe942c4d29bdecb194e41ca37
 timeCreated: 1504423936
 licenseType: Pro
 MonoImporter:

--- a/src/n-ui/PropertyBinding.cs
+++ b/src/n-ui/PropertyBinding.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using N.Tests;
+using N.Package.Core.Tests;
 using N;
 
 namespace N.Package.UI {
@@ -24,16 +24,16 @@ namespace N.Package.UI {
     public PropertyInfo info;
 
     /// Actual property references
-    private N.Reflect.Prop sourceProp = null;
-    private N.Reflect.Prop targetProp = null;
+    private N.Package.Core.Reflect.Prop sourceProp = null;
+    private N.Package.Core.Reflect.Prop targetProp = null;
     private Component sourceCmp = null;
     private Component targetCmp = null;
     private bool ready = false;
 
     /// Resolve source and target property instances
     public void Start() {
-      var sp = N.Reflect.Type.Field(info.sourceComponent, info.sourceProperty);
-      var tp = N.Reflect.Type.Field(info.targetComponent, info.targetProperty);
+      var sp = N.Package.Core.Reflect.Type.Field(info.sourceComponent, info.sourceProperty);
+      var tp = N.Package.Core.Reflect.Type.Field(info.targetComponent, info.targetProperty);
       if (sp.IsSome && tp.IsSome) {
         sourceProp = sp.Unwrap();
         sourceCmp = source.GetComponent(sourceProp.Type);
@@ -43,10 +43,10 @@ namespace N.Package.UI {
       }
       else {
         if (tp.IsNone) {
-          N.Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.targetComponent, info.targetProperty, gameObject));
+          N.Package.Core.Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.targetComponent, info.targetProperty, gameObject));
         }
         if (sp.IsNone) {
-          N.Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.sourceComponent, info.sourceProperty, gameObject));
+          N.Package.Core.Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.sourceComponent, info.sourceProperty, gameObject));
         }
       }
     }

--- a/src/n-ui/PropertyBinding.cs
+++ b/src/n-ui/PropertyBinding.cs
@@ -1,13 +1,11 @@
 using UnityEngine;
-using N.Package.Core.Tests;
-using N;
-namespace N.Package.UI
+using N.Package.Core.Reflect;
 
-{
+namespace N.Package.UI {
+
   /// Folder for child properties
   [System.Serializable]
-  public class PropertyInfo
-  {
+  public class PropertyInfo {
     public string sourceComponent;
     public string sourceProperty;
     public string targetComponent;
@@ -16,48 +14,45 @@ namespace N.Package.UI
 
   /// Add this to an object to copy some property from some object overlaps
   /// when the other object changes state.
-  public class PropertyBinding : MonoBehaviour
-  {
-    [Tooltip("The object to copy the property value from")] public GameObject source;
+  public class PropertyBinding : MonoBehaviour {
 
-    [Tooltip("The actual bound values")] public PropertyInfo info;
+    [Tooltip("The object to copy the property value from")]
+    public GameObject source;
+
+    [Tooltip("The actual bound values")]
+    public PropertyInfo info;
 
     /// Actual property references
-    private N.Package.Core.Reflect.Prop sourceProp = null;
-    private N.Package.Core.Reflect.Prop targetProp = null;
+    private Prop sourceProp = null;
+    private Prop targetProp = null;
     private Component sourceCmp = null;
     private Component targetCmp = null;
     private bool ready = false;
 
     /// Resolve source and target property instances
-    public void Start()
-    {
-      var sp = N.Package.Core.Reflect.Type.Field(info.sourceComponent, info.sourceProperty);
-      var tp = N.Package.Core.Reflect.Type.Field(info.targetComponent, info.targetProperty);
-      if (sp.IsSome && tp.IsSome)
-      {
+    public void Start() {
+      var sp = Type.Field(info.sourceComponent, info.sourceProperty);
+      var tp = Type.Field(info.targetComponent, info.targetProperty);
+      if (sp.IsSome && tp.IsSome) {
         sourceProp = sp.Unwrap();
         sourceCmp = source.GetComponent(sourceProp.Type);
         targetProp = tp.Unwrap();
         targetCmp = GetComponent(targetProp.Type);
         ready = true;
-      } else {
-        if (tp.IsNone)
-        {
-          N.Package.Core.Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.targetComponent, info.targetProperty, gameObject));
+      }
+      else {
+        if (tp.IsNone) {
+          Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.targetComponent, info.targetProperty, gameObject));
         }
-        if (sp.IsNone)
-        {
-          N.Package.Core.Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.sourceComponent, info.sourceProperty, gameObject));
+        if (sp.IsNone) {
+          Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.sourceComponent, info.sourceProperty, gameObject));
         }
       }
     }
 
     /// Push source property value to target
-    public void Update()
-    {
-      if (ready)
-      {
+    public void Update() {
+      if (ready) {
         sourceProp.Bind(sourceCmp, targetProp, targetCmp);
       }
     }

--- a/src/n-ui/PropertyBinding.cs
+++ b/src/n-ui/PropertyBinding.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using N.Package.Core;
 using N.Package.Core.Reflect;
 
 namespace N.Package.UI {

--- a/src/n-ui/PropertyBinding.cs
+++ b/src/n-ui/PropertyBinding.cs
@@ -6,7 +6,8 @@ namespace N.Package.UI {
 
   /// Folder for child properties
   [System.Serializable]
-  public class PropertyInfo {
+  public class PropertyInfo
+  {
     public string sourceComponent;
     public string sourceProperty;
     public string targetComponent;
@@ -15,7 +16,8 @@ namespace N.Package.UI {
 
   /// Add this to an object to copy some property from some object overlaps
   /// when the other object changes state.
-  public class PropertyBinding : MonoBehaviour {
+  public class PropertyBinding : MonoBehaviour
+  {
 
     [Tooltip("The object to copy the property value from")]
     public GameObject source;
@@ -31,7 +33,8 @@ namespace N.Package.UI {
     private bool ready = false;
 
     /// Resolve source and target property instances
-    public void Start() {
+    public void Start()
+    {
       var sp = Type.Field(info.sourceComponent, info.sourceProperty);
       var tp = Type.Field(info.targetComponent, info.targetProperty);
       if (sp.IsSome && tp.IsSome) {
@@ -42,18 +45,22 @@ namespace N.Package.UI {
         ready = true;
       }
       else {
-        if (tp.IsNone) {
+        if (tp.IsNone)
+        {
           Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.targetComponent, info.targetProperty, gameObject));
         }
-        if (sp.IsNone) {
+        if (sp.IsNone)
+        {
           Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.sourceComponent, info.sourceProperty, gameObject));
         }
       }
     }
 
     /// Push source property value to target
-    public void Update() {
-      if (ready) {
+    public void Update()
+    {
+      if (ready)
+      {
         sourceProp.Bind(sourceCmp, targetProp, targetCmp);
       }
     }

--- a/src/n-ui/PropertyBinding.cs
+++ b/src/n-ui/PropertyBinding.cs
@@ -23,9 +23,6 @@ namespace N.Package.UI
     [Tooltip("The actual bound values")] public PropertyInfo info;
 
     /// Actual property references
-    private Prop sourceProp = null;
-
-    /// Actual property references
     private N.Package.Core.Reflect.Prop sourceProp = null;
     private N.Package.Core.Reflect.Prop targetProp = null;
     private Component sourceCmp = null;
@@ -37,25 +34,21 @@ namespace N.Package.UI
     {
       var sp = N.Package.Core.Reflect.Type.Field(info.sourceComponent, info.sourceProperty);
       var tp = N.Package.Core.Reflect.Type.Field(info.targetComponent, info.targetProperty);
-      if (sp.IsSome && tp.IsSome) {
+      if (sp.IsSome && tp.IsSome)
       {
         sourceProp = sp.Unwrap();
         sourceCmp = source.GetComponent(sourceProp.Type);
         targetProp = tp.Unwrap();
         targetCmp = GetComponent(targetProp.Type);
         ready = true;
-      }
-      else
-      {
+      } else {
         if (tp.IsNone)
         {
           N.Package.Core.Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.targetComponent, info.targetProperty, gameObject));
-            info.targetProperty, gameObject));
         }
         if (sp.IsNone)
         {
           N.Package.Core.Console.Log(string.Format("Property Binding {0}.{1} on {2} is not valid", info.sourceComponent, info.sourceProperty, gameObject));
-            info.sourceProperty, gameObject));
         }
       }
     }

--- a/src/n-ui/PropertyBinding.cs.meta
+++ b/src/n-ui/PropertyBinding.cs.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
-guid: f2f1d53593009418a9ad239ef2309c22
-timeCreated: 1480137314
-licenseType: Free
+guid: 4d14692cf0cea44dabe993555a86d4e4
+timeCreated: 1504423937
+licenseType: Pro
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []

--- a/src/n-ui/ReadOnlyPropertyInspector.cs
+++ b/src/n-ui/ReadOnlyPropertyInspector.cs
@@ -1,0 +1,71 @@
+﻿#if UNITY_EDITOR
+using UnityEngine;
+using UnityEditor;
+
+namespace N.Package.UI
+{
+    /// <summary>
+    /// Make a property visible in editor, but not modifyable.
+    /// Works for: Int, Bool, Float, String, Vector2, Vector3, Vector4,
+    ///   Quaternion, Enum
+    /// </summary>
+    public class ReadOnlyPropertyInspector : PropertyAttribute
+    {
+        public ReadOnlyPropertyInspector() { }
+    }
+
+    /// <summary>
+    /// Render the read-only properties.
+    /// </summary>
+    [CustomPropertyDrawer(typeof(ReadOnlyPropertyInspector))]
+    public class ReadOnlyPropertyInspectorDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty prop, GUIContent label)
+        {
+            string valueStr;
+
+            switch (prop.propertyType)
+            {
+                case SerializedPropertyType.Integer:
+                    valueStr = prop.intValue.ToString();
+                    break;
+                case SerializedPropertyType.Boolean:
+                    valueStr = prop.boolValue.ToString();
+                    break;
+                case SerializedPropertyType.Float:
+                    valueStr = prop.floatValue.ToString("0.00000");
+                    break;
+                case SerializedPropertyType.String:
+                    valueStr = prop.stringValue;
+                    break;
+                case SerializedPropertyType.Vector2:
+                    valueStr = prop.vector2Value.ToString();
+                    break;
+                case SerializedPropertyType.Vector3:
+                    valueStr = prop.vector3Value.ToString();
+                    break;
+                case SerializedPropertyType.Vector4:
+                    valueStr = prop.vector4Value.ToString();
+                    break;
+                case SerializedPropertyType.Quaternion:
+                    valueStr = prop.quaternionValue.ToString();
+                    break;
+                case SerializedPropertyType.Enum:
+                    valueStr = prop.enumNames[prop.enumValueIndex];
+                    break;
+                default:
+                    valueStr = prop.propertyType + ": not supported";
+                    break;
+            }
+
+            EditorGUI.LabelField(position, label.text, valueStr);
+        }
+    }
+}
+#else
+ 
+namespace N.Package.UI
+{
+    public class ReadOnlyPropertyInspector : System.Attribute { }
+}
+#endif

--- a/src/n-ui/ReadOnlyPropertyInspector.cs.meta
+++ b/src/n-ui/ReadOnlyPropertyInspector.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 0605157c6275841eca3027bf036c37d7
-timeCreated: 1504423936
+guid: 75270f01c08ec4c549169c5e830203f2
+timeCreated: 1504423937
 licenseType: Pro
 MonoImporter:
   serializedVersion: 2

--- a/src/n-ui/UiController.cs
+++ b/src/n-ui/UiController.cs
@@ -19,48 +19,44 @@ namespace N.Package.UI {
     private bool initialized = false;
 
     /// Periodically update the UI
-    public void Update() {
-      if (!initialized) {
-        Init();
-      }
-      if (dirty) {
+    public void Update()
+    {
+      if (!initialized) Init();
+      if (dirty)
+      {
         Redraw();
-      }
-      else {
+      } else {
         elapsed += Time.deltaTime;
-        if (elapsed > updateInterval) {
-          dirty = true;
-        }
+        if (elapsed > updateInterval) dirty = true;
       }
       Pick();
     }
 
     /// Poll for raycast object picking
-    protected virtual void Pick() {
-    }
+    protected virtual void Pick() { }
 
     /// Load all the tags we can find.
     /// Call this in Start() on the child class, as unity cannot resolve
     /// Start() methods in parent classes.
-    protected void Init() {
+    protected void Init()
+    {
       initialized = true;
       var targets = Marker.Find(Tags(), gameObject);
-      if (targets) {
+      if (targets)
+      {
         Setup(targets.Unwrap());
         Redraw();
-      }
-      else {
+      } else {
         Console.Error("Failed to load UI targets");
       }
     }
 
     /// Redraw the UI
-    public void Redraw() {
+    public void Redraw()
+    {
       dirty = false;
       elapsed = 0f;
-      if (Ready()) {
-        Sync();
-      }
+      if (Ready()) Sync();
     }
 
     /// Run periodically and only start this UI once it returns true.

--- a/src/n-ui/UiController.cs
+++ b/src/n-ui/UiController.cs
@@ -1,7 +1,5 @@
 using UnityEngine;
-using UnityEngine.UI;
-using N;
-using N.Package.UI;
+using N.Package.Core;
 using System.Collections.Generic;
 
 namespace N.Package.UI {
@@ -52,7 +50,7 @@ namespace N.Package.UI {
         Redraw();
       }
       else {
-        N.Console.Error("Failed to load UI targets");
+        Console.Error("Failed to load UI targets");
       }
     }
 

--- a/src/n-ui/UiController.cs
+++ b/src/n-ui/UiController.cs
@@ -1,13 +1,13 @@
 using UnityEngine;
 using UnityEngine.UI;
-using N.Package.Core;
+using N;
 using N.Package.UI;
 using System.Collections.Generic;
 
-namespace N.Package.UI
-{
-  public abstract class UiController : MonoBehaviour
-  {
+namespace N.Package.UI {
+
+  public abstract class UiController : MonoBehaviour {
+
     [Tooltip("Does the UI state need to be updated?")]
     public bool dirty = true;
 
@@ -21,21 +21,16 @@ namespace N.Package.UI
     private bool initialized = false;
 
     /// Periodically update the UI
-    public void Update()
-    {
-      if (!initialized)
-      {
+    public void Update() {
+      if (!initialized) {
         Init();
       }
-      if (dirty)
-      {
+      if (dirty) {
         Redraw();
       }
-      else
-      {
+      else {
         elapsed += Time.deltaTime;
-        if (elapsed > updateInterval)
-        {
+        if (elapsed > updateInterval) {
           dirty = true;
         }
       }
@@ -43,35 +38,29 @@ namespace N.Package.UI
     }
 
     /// Poll for raycast object picking
-    protected virtual void Pick()
-    {
+    protected virtual void Pick() {
     }
 
     /// Load all the tags we can find.
     /// Call this in Start() on the child class, as unity cannot resolve
     /// Start() methods in parent classes.
-    protected void Init()
-    {
+    protected void Init() {
       initialized = true;
       var targets = Marker.Find(Tags(), gameObject);
-      if (targets)
-      {
+      if (targets) {
         Setup(targets.Unwrap());
         Redraw();
       }
-      else
-      {
-        Console.Error("Failed to load UI targets");
+      else {
+        N.Console.Error("Failed to load UI targets");
       }
     }
 
     /// Redraw the UI
-    public void Redraw()
-    {
+    public void Redraw() {
       dirty = false;
       elapsed = 0f;
-      if (Ready())
-      {
+      if (Ready()) {
         Sync();
       }
     }

--- a/src/n-ui/UiController.cs
+++ b/src/n-ui/UiController.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-using N;
+using N.Package.Core;
 using N.Package.UI;
 using System.Collections.Generic;
 
@@ -52,7 +52,7 @@ namespace N.Package.UI {
         Redraw();
       }
       else {
-        N.Console.Error("Failed to load UI targets");
+        Console.Error("Failed to load UI targets");
       }
     }
 

--- a/src/n-ui/extensions.meta
+++ b/src/n-ui/extensions.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: fa9664ff1569f4c8ead5bb2eb0005cf6
+guid: 26f91fefc412c4052994ed9eb46d76c5
 folderAsset: yes
-timeCreated: 1480137314
-licenseType: Free
+timeCreated: 1504423936
+licenseType: Pro
 DefaultImporter:
   userData: 
   assetBundleName: 

--- a/src/n-ui/extensions/Editor.meta
+++ b/src/n-ui/extensions/Editor.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 189a2a2a56ab0491f900f7bd174c6270
+guid: 2c77cca06e4d04d88818c054c8815672
 folderAsset: yes
-timeCreated: 1480137314
-licenseType: Free
+timeCreated: 1504423936
+licenseType: Pro
 DefaultImporter:
   userData: 
   assetBundleName: 

--- a/src/n-ui/extensions/GameObjectUiExtensions.cs
+++ b/src/n-ui/extensions/GameObjectUiExtensions.cs
@@ -4,117 +4,119 @@ using N.Package.Core;
 
 namespace N.Package.UI
 {
-  /// Camera extension methods
-  public static class GameObjectUiExtensions
-  {
-    /// Set the value of a slider
-    public static bool SetSlider(this GameObject target, float value)
+    /// Camera extension methods
+    public static class GameObjectUiExtensions
     {
-      var slider = target.GetComponent<Slider>();
-      if (slider != null)
-      {
-        slider.normalizedValue = value;
-        return true;
-      }
-      return false;
-    }
-
-    /// Set the value of a text area
-    public static bool SetText(this GameObject target, string value)
-    {
-      // Normal text type?
-      var text = target.GetComponent<Text>();
-      if (text != null)
-      {
-        text.text = value;
-        return true;
-      }
-
-      // For a button, etc where there's a child Text object?
-      text = target.GetComponentInChildren<Text>();
-      if (text != null)
-      {
-        text.text = value;
-        return true;
-      }
-
-      return false;
-    }
-
-    /// Set the value of a text area
-    public static bool SetText(this GameObject target, string format, params object[] args)
-    {
-      var msg = string.Format(format, args);
-      return target.SetText(msg);
-    }
-
-    /// Set the color of some text
-    public static bool SetTextColor(this GameObject target, Color value)
-    {
-      // Normal text type?
-      var text = target.GetComponent<Text>();
-      if (text != null)
-      {
-        text.color = value;
-        return true;
-      }
-
-      // For a button, etc where there's a child Text object?
-      text = target.GetComponentInChildren<Text>();
-      if (text != null)
-      {
-        text.color = value;
-        return true;
-      }
-
-      return false;
-    }
-
-    /// Set the value of a text area
-    public static bool SetEnabled(this GameObject target, bool value)
-    {
-      var active = target.GetComponent<Selectable>();
-      if (active != null)
-      {
-        active.interactable = value;
-        return true;
-      }
-      return false;
-    }
-
-    /// Add a child elements to a scrollable block.
-    /// Use this on the 'Content' elements of a ScrollView UI item.
-    /// @param child The child object to add, notice it must have a fixed height
-    /// @param offset The offset into the scrollable region
-    public static void AddChildToRegion(this GameObject self, GameObject child, int offset)
-    {
-      var pt = self.GetComponent<RectTransform>();
-      var ct = child.GetComponent<RectTransform>();
-      var magic = ct.sizeDelta.y;
-      pt.sizeDelta = pt.sizeDelta + new Vector2(0f, magic);
-      child.SetParent(self);
-      ct.offsetMin = new Vector2(0f, -magic * offset);
-      ct.offsetMax = new Vector2(0f, -magic * offset + magic);
-    }
-
-    /// Find Marker
-    public static Option<GameObject> Marker(this GameObject target, string name)
-    {
-      return N.Package.Core.Marker.Find(name, target);
-    }
-
-    /// Add a click event to a button
-    public static void AddClickEvent(this GameObject target, UnityEngine.Events.UnityAction callback, bool replaceExistingEvents = true)
-    {
-      var button = target.GetComponent<Button>();
-      if (button != null)
-      {
-        if (replaceExistingEvents)
+        /// Set the value of a slider
+        public static bool SetSlider(this GameObject target, float value)
         {
-          button.onClick.RemoveAllListeners();
+            var slider = target.GetComponent<Slider>();
+            if (slider != null)
+            {
+                slider.normalizedValue = value;
+                return true;
+            }
+            return false;
         }
-        button.onClick.AddListener(callback);
-      }
+
+        /// Set the value of a text area
+        public static bool SetText(this GameObject target, string value)
+        {
+
+            // Normal text type?
+            var text = target.GetComponent<Text>();
+            if (text != null)
+            {
+                text.text = value;
+                return true;
+            }
+
+            // For a button, etc where there's a child Text object?
+            text = target.GetComponentInChildren<Text>();
+            if (text != null)
+            {
+                text.text = value;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// Set the value of a text area
+        public static bool SetText(this GameObject target, string format, params object[] args)
+        {
+            var msg = string.Format(format, args);
+            return target.SetText(msg);
+        }
+
+        /// Set the color of some text
+        public static bool SetTextColor(this GameObject target, Color value)
+        {
+
+            // Normal text type?
+            var text = target.GetComponent<Text>();
+            if (text != null)
+            {
+                text.color = value;
+                return true;
+            }
+
+            // For a button, etc where there's a child Text object?
+            text = target.GetComponentInChildren<Text>();
+            if (text != null)
+            {
+                text.color = value;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// Set the value of a text area
+        public static bool SetEnabled(this GameObject target, bool value)
+        {
+            var active = target.GetComponent<Selectable>();
+            if (active != null)
+            {
+                active.interactable = value;
+                return true;
+            }
+            return false;
+        }
+
+        /// Add a child elements to a scrollable block.
+        /// Use this on the 'Content' elements of a ScrollView UI item.
+        /// @param child The child object to add, notice it must have a fixed height
+        /// @param offset The offset into the scrollable region
+        public static void AddChildToRegion(this GameObject self, GameObject child, int offset)
+        {
+            var pt = self.GetComponent<RectTransform>();
+            var ct = child.GetComponent<RectTransform>();
+            var magic = ct.sizeDelta.y;
+            pt.sizeDelta = pt.sizeDelta + new Vector2(0f, magic);
+            child.SetParent(self);
+            ct.offsetMin = new Vector2(0f, -magic * offset);
+            ct.offsetMax = new Vector2(0f, -magic * offset + magic);
+        }
+
+        /// Find Marker
+        public static Option<GameObject> Marker(this GameObject target, string name)
+        {
+            return N.Marker.Find(name, target);
+        }
+
+        /// Add a click event to a button
+        public static void AddClickEvent(this GameObject target, UnityEngine.Events.UnityAction callback, bool replaceExistingEvents = true)
+        {
+            var button = target.GetComponent<Button>();
+            if (button != null)
+            {
+                if (replaceExistingEvents)
+                {
+                    button.onClick.RemoveAllListeners();
+                }
+                button.onClick.AddListener(callback);
+            }
+        }
     }
-  }
 }

--- a/src/n-ui/extensions/GameObjectUiExtensions.cs
+++ b/src/n-ui/extensions/GameObjectUiExtensions.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-using N.Tests;
+using N.Package.Core.Tests;
 
 namespace N.Package.UI
 {
@@ -94,15 +94,15 @@ namespace N.Package.UI
             var ct = child.GetComponent<RectTransform>();
             var magic = ct.sizeDelta.y;
             pt.sizeDelta = pt.sizeDelta + new Vector2(0f, magic);
-            child.SetParent(self);
+            child.transform.SetParent(self.transform);
             ct.offsetMin = new Vector2(0f, -magic * offset);
             ct.offsetMax = new Vector2(0f, -magic * offset + magic);
         }
 
         /// Find Marker
-        public static Option<GameObject> Marker(this GameObject target, string name)
+        public static N.Package.Core.Option<GameObject> Marker(this GameObject target, string name)
         {
-            return N.Marker.Find(name, target);
+            return N.Package.Core.Marker.Find(name, target);
         }
 
         /// Add a click event to a button

--- a/src/n-ui/extensions/GameObjectUiExtensions.cs
+++ b/src/n-ui/extensions/GameObjectUiExtensions.cs
@@ -102,7 +102,7 @@ namespace N.Package.UI
         /// Find Marker
         public static Option<GameObject> Marker(this GameObject target, string name)
         {
-            return N.Marker.Find(name, target);
+            return N.Package.Core.Marker.Find(name, target);
         }
 
         /// Add a click event to a button

--- a/src/n-ui/extensions/GameObjectUiExtensions.cs
+++ b/src/n-ui/extensions/GameObjectUiExtensions.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-using N.Package.Core.Tests;
+using N.Package.Core;
 
 namespace N.Package.UI
 {
@@ -112,30 +112,7 @@ namespace N.Package.UI
         if (replaceExistingEvents)
         {
           button.onClick.RemoveAllListeners();
-            var ct = child.GetComponent<RectTransform>();
-            var magic = ct.sizeDelta.y;
-            pt.sizeDelta = pt.sizeDelta + new Vector2(0f, magic);
-            child.transform.SetParent(self.transform);
-            ct.offsetMin = new Vector2(0f, -magic * offset);
-            ct.offsetMax = new Vector2(0f, -magic * offset + magic);
         }
-
-        /// Find Marker
-        public static N.Package.Core.Option<GameObject> Marker(this GameObject target, string name)
-        {
-            return N.Package.Core.Marker.Find(name, target);
-        }
-
-        /// Add a click event to a button
-        public static void AddClickEvent(this GameObject target, UnityEngine.Events.UnityAction callback, bool replaceExistingEvents = true)
-        {
-            var button = target.GetComponent<Button>();
-            if (button != null)
-            {
-                if (replaceExistingEvents)
-                {
-                    button.onClick.RemoveAllListeners();
-                }
         button.onClick.AddListener(callback);
       }
     }

--- a/src/n-ui/tools.meta
+++ b/src/n-ui/tools.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 7d0641ccbac4a4d4d83b43916c9a6799
+guid: a0db41cf1f645413e9aefa5c424d30ad
 folderAsset: yes
-timeCreated: 1480137314
-licenseType: Free
+timeCreated: 1504423936
+licenseType: Pro
 DefaultImporter:
   userData: 
   assetBundleName: 

--- a/src/n-ui/tools/Editor/EditorSelectProperty.cs
+++ b/src/n-ui/tools/Editor/EditorSelectProperty.cs
@@ -22,7 +22,7 @@ namespace N.UI.Tools {
     public void bind(System.Object obj) {
       if (target != obj) {
         options.Clear();
-        foreach (var f in N.Reflect.Type.Fields(obj)) {
+        foreach (var f in N.Package.Core.Reflect.Type.Fields(obj)) {
           options.Add(f);
         }
       }

--- a/src/n-ui/tools/Editor/EditorSelectProperty.cs
+++ b/src/n-ui/tools/Editor/EditorSelectProperty.cs
@@ -1,9 +1,3 @@
-using UnityEngine;
-using UnityEditor;
-using System.Collections.Generic;
-using System;
-using N;
-
 namespace N.UI.Tools {
 
   /// An editor drop down to pick a component from the parent game object
@@ -22,7 +16,7 @@ namespace N.UI.Tools {
     public void bind(System.Object obj) {
       if (target != obj) {
         options.Clear();
-        foreach (var f in N.Reflect.Type.Fields(obj)) {
+        foreach (var f in N.Package.Core.Reflect.Type.Fields(obj)) {
           options.Add(f);
         }
       }

--- a/src/n-ui/tools/Editor/EditorSelectProperty.cs
+++ b/src/n-ui/tools/Editor/EditorSelectProperty.cs
@@ -7,16 +7,20 @@ namespace N.UI.Tools {
     private System.Object target;
 
     /// Create a new instance
-    public EditorSelectProperty(string name, string value) : base(name, value) {
+    public EditorSelectProperty(string name, string value) : base(name, value)
+    {
       target = null;
     }
 
     /// Call this every update to ensure the gamae object is synced
     /// to the list of the components in the drop down.
-    public void bind(System.Object obj) {
-      if (target != obj) {
+    public void bind(System.Object obj)
+    {
+      if (target != obj)
+      {
         options.Clear();
-        foreach (var f in N.Package.Core.Reflect.Type.Fields(obj)) {
+        foreach (var f in N.Package.Core.Reflect.Type.Fields(obj))
+        {
           options.Add(f);
         }
       }

--- a/src/n-ui/tools/Editor/EditorSelectProperty.cs
+++ b/src/n-ui/tools/Editor/EditorSelectProperty.cs
@@ -1,4 +1,8 @@
-using N.Package.Core.Reflect;
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System;
+using N;
 
 namespace N.UI.Tools {
 
@@ -18,7 +22,7 @@ namespace N.UI.Tools {
     public void bind(System.Object obj) {
       if (target != obj) {
         options.Clear();
-        foreach (var f in N.Package.Core.Reflect.Type.Fields(obj)) {
+        foreach (var f in N.Reflect.Type.Fields(obj)) {
           options.Add(f);
         }
       }


### PR DESCRIPTION
Also verify that this works with Core as of [b459653](https://github.com/StirfireStudios/unity-n-core/commit/b459653576361f2ecc70ee64f4c6871f316432a6) - should probably look at [PR #2](https://github.com/shadowmint/unity-n-core/pull/2) there before merging this. 

`[N.Package.UI.ReadOnlyPropertyInspector]` on a Serialised private field makes it viewable in the editor without using debug mode. Works for the following types:
  * `Integer`
  * `Boolean`
  * `Float`
  * `String` 
  * `Vector2`, `Vector3`, `Vector4` and `Quaternion`

For an unsupported type an error will be displayed. 

`[N.Package.UI.FlagInspector]` on a Flag Enum will display it properly. 